### PR TITLE
Fix api refresh token

### DIFF
--- a/darwinexapis/API/DWX_API_Auth.py
+++ b/darwinexapis/API/DWX_API_Auth.py
@@ -91,7 +91,7 @@ class DWX_API_AUTHENTICATION(object):
         # This way we have the base64 codification of the key:secret into a string, which is required for the request to the API.
         encoded_key_secret = base64.b64encode(bytes_string).decode('utf-8')
 
-        # Creating a headers dictionary to have all data nicely formatted for the request
+        # Creating a headers dictionary to have all headers data nicely formatted for the request
         headers = CaseInsensitiveDict()
         headers["Authorization"] = f"Basic {encoded_key_secret}"
         headers["Content-Type"] = "application/x-www-form-urlencoded"


### PR DESCRIPTION
This change implements a curl-like request to solve an HTTP error "400 Client Error: Bad Request for url: https://api.darwinex.com/token)" when trying to refresh the API Access Token.

The content type in the header is now "application/x-www-form-urlencoded".

It also makes the base64 encoding process step-by-step for better readability.

Best regards,
Marti Castany - KomaLogic